### PR TITLE
Fix broken build by including homepage config

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "gen:station-routes": "babel-node _scripts/gen-station-routes-data.js",
     "gen:mock:etd": "babel-node _scripts/gen-mock-etd-data.js"
   },
+  "homepage": "/bart-salmon",
   "lint-staged": {
     "src/**/*.{js,jsx,json,css}": ["yarn format", "git add"]
   },

--- a/src/components/Selector/Selector.styles.web.js
+++ b/src/components/Selector/Selector.styles.web.js
@@ -31,5 +31,8 @@ export default {
     height: '100%',
     top: 0,
     left: 0,
+
+    // #6 - allows for adjusting height of <select> in iOS
+    webkitAppearance: 'menulist-button',
   },
 }


### PR DESCRIPTION
When site is published, it's at http://www.benmvp.com/bart-salmon/ so need to specify `/bart-salmon` in `package.json` as configuration.

Also specifying `-webkit-appearance: menulist-button` in order to fix iOS `<select>` height issue to fix #6 