### PR TITLE
Add station swap button

### DIFF
--- a/src/components/RoutesPage.styles.ts
+++ b/src/components/RoutesPage.styles.ts
@@ -1,37 +1,19 @@
-import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
+import { makeStyles } from '@material-ui/core/styles';
 
-export default makeStyles((theme: Theme) => (
-  createStyles({
-    root: {
-      flex: 1,
+export default makeStyles({
+  root: {
+    flex: 1,
 
-      display: 'flex',
-      flexDirection: 'column',
-      justifyContent: 'space-between',
-      alignItems: 'center',
-    },
-    stationSelectors: {
-      width: '100%',
-      padding: theme.spacing(2),
-    },
-    stationSelector: {
-      marginBottom: theme.spacing(2),
-      display: 'flex',
-      flexDirection: 'row',
-      justifyContent: 'space-between',
-    },
-    stationSelectorIcon: {
-      marginRight: theme.spacing(1),
-    },
-    stationSelectorFormControl: {
-      flex: 1,
-    },
-    arrivals: {
-      width: '100%',
-    },
-    salmonRoutes: {
-      flex: 1,
-      width: '100%',
-    },
-  })
-))
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  arrivals: {
+    width: '100%',
+  },
+  salmonRoutes: {
+    flex: 1,
+    width: '100%',
+  },
+})

--- a/src/components/RoutesPage.tsx
+++ b/src/components/RoutesPage.tsx
@@ -1,7 +1,7 @@
 import React, {useEffect} from 'react'
 import isEmpty from 'lodash/isEmpty'
 import Arrivals from './Arrivals'
-import StationSelectors, {StationChange} from './StationSelectors';
+import StationSelectors, {StationsChange} from './StationSelectors';
 import SalmonRoutes from './SalmonRoutes'
 import {SalmonRoute, Train} from '../utils/types'
 import {OptionalStationName} from '../store/types'
@@ -16,8 +16,7 @@ interface Props {
   salmonRoutes: SalmonRoute[];
   arrivals: Train[];
   numArrivals: number;
-  setOrigin: StationChange;
-  setDestination: StationChange;
+  setStations: StationsChange;
   getSalmonInfo: () => void;
   isDisabled: boolean;
 }
@@ -26,8 +25,7 @@ const RoutesPage= ({
   origin,
   destination,
   numSalmonRoutes,
-  setOrigin,
-  setDestination,
+  setStations,
   getSalmonInfo,
   salmonRoutes,
   arrivals,
@@ -70,9 +68,8 @@ const RoutesPage= ({
     <div className={classes.root}>
       <StationSelectors
         origin={origin}
-        onOriginChange={setOrigin}
         destination={destination}
-        onDestinationChange={setDestination}
+        onStationsChange={setStations}
       />
       {arrivalsAndRoutes}
     </div>

--- a/src/components/RoutesPage.tsx
+++ b/src/components/RoutesPage.tsx
@@ -1,53 +1,12 @@
-import React, {useEffect, ReactNode} from 'react'
+import React, {useEffect} from 'react'
 import isEmpty from 'lodash/isEmpty'
-import kebabCase from 'lodash/kebabCase'
-import LocationOnIcon from '@material-ui/icons/LocationOn';
-import TripOriginIcon from '@material-ui/icons/TripOrigin';
 import Arrivals from './Arrivals'
+import StationSelectors, {StationChange} from './StationSelectors';
 import SalmonRoutes from './SalmonRoutes'
-import Selector from './Selector'
-import {SalmonRoute, Train, StationLookup} from '../utils/types'
+import {SalmonRoute, Train} from '../utils/types'
 import {OptionalStationName} from '../store/types'
-import stationsLookup from '../data/stations.json'
 
 import useStyles from './RoutesPage.styles'
-
-
-const STATIONS_LOOKUP = (stationsLookup as unknown) as StationLookup
-
-const STATIONS_SELECTOR_VALUES = Object.values(STATIONS_LOOKUP)
-  .map(({name, abbr}) => ({value: abbr as OptionalStationName, display: name}))
-
-interface StationSelectorProps {
-  label: string;
-  station: OptionalStationName;
-  icon: ReactNode;
-  onChange: (stationName: OptionalStationName) => void;
-}
-const StationSelector = ({label, station, icon, onChange}: StationSelectorProps) => {
-  const classes = useStyles()
-  const values = [
-    { value: '' as OptionalStationName, display: '' },
-    ...STATIONS_SELECTOR_VALUES,
-  ]
-
-  const selector = Selector<OptionalStationName>({
-    id: kebabCase(`${label}-station-selector`),
-    label,
-    value: station,
-    values,
-    onChange,
-  })
-
-  return (
-    <div className={classes.stationSelector}>
-      <span className={classes.stationSelectorIcon}>
-        {icon}
-      </span>
-      {selector}
-    </div>
-  )
-}
 
 
 interface Props {
@@ -57,8 +16,8 @@ interface Props {
   salmonRoutes: SalmonRoute[];
   arrivals: Train[];
   numArrivals: number;
-  setOrigin: (name: OptionalStationName) => void;
-  setDestination: (name: OptionalStationName) => void;
+  setOrigin: StationChange;
+  setDestination: StationChange;
   getSalmonInfo: () => void;
   isDisabled: boolean;
 }
@@ -109,20 +68,12 @@ const RoutesPage= ({
 
   return (
     <div className={classes.root}>
-      <section className={classes.stationSelectors}>
-        <StationSelector
-          label="Origin"
-          station={origin}
-          icon={<TripOriginIcon />}
-          onChange={setOrigin}
-        />
-        <StationSelector
-          label="Destination"
-          station={destination}
-          icon={<LocationOnIcon />}
-          onChange={setDestination}
-        />
-      </section>
+      <StationSelectors
+        origin={origin}
+        onOriginChange={setOrigin}
+        destination={destination}
+        onDestinationChange={setDestination}
+      />
       {arrivalsAndRoutes}
     </div>
   )

--- a/src/components/StationSelectors.styles.ts
+++ b/src/components/StationSelectors.styles.ts
@@ -1,0 +1,19 @@
+import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
+
+export default makeStyles((theme: Theme) => (
+  createStyles({
+    root: {
+      width: '100%',
+      padding: theme.spacing(2),
+    },
+    selector: {
+      marginBottom: theme.spacing(2),
+      display: 'flex',
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+    },
+    selectorIcon: {
+      marginRight: theme.spacing(1),
+    },
+  })
+))

--- a/src/components/StationSelectors.styles.ts
+++ b/src/components/StationSelectors.styles.ts
@@ -3,17 +3,27 @@ import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 export default makeStyles((theme: Theme) => (
   createStyles({
     root: {
-      width: '100%',
-      padding: theme.spacing(2),
-    },
-    selector: {
-      marginBottom: theme.spacing(2),
+      alignItems: 'center',
       display: 'flex',
       flexDirection: 'row',
       justifyContent: 'space-between',
+      padding: theme.spacing(2),
+      width: '100%',
+    },
+    selectors: {
+      flex: 1,
+    },
+    selector: {
+      display: 'flex',
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      marginBottom: theme.spacing(2),
     },
     selectorIcon: {
       marginRight: theme.spacing(1),
     },
+    swapButton: {
+      marginLeft: theme.spacing(1),
+    }
   })
 ))

--- a/src/components/StationSelectors.tsx
+++ b/src/components/StationSelectors.tsx
@@ -4,7 +4,7 @@ import kebabCase from 'lodash/kebabCase'
 import IconButton from '@material-ui/core/IconButton';
 import LocationOnIcon from '@material-ui/icons/LocationOn'
 import TripOriginIcon from '@material-ui/icons/TripOrigin'
-import SyncIcon from '@material-ui/icons/Sync'
+import SwapVertIcon from '@material-ui/icons/SwapVert'
 
 import Selector from './Selector'
 import {StationLookup} from '../utils/types'
@@ -96,7 +96,7 @@ const StationSelectors = ({
         aria-label="Swap stations"
         onClick={onStationSwap}
       >
-        <SyncIcon />
+        <SwapVertIcon />
       </IconButton>
     </section>
   )

--- a/src/components/StationSelectors.tsx
+++ b/src/components/StationSelectors.tsx
@@ -1,0 +1,86 @@
+import React, {ReactNode} from 'react'
+import kebabCase from 'lodash/kebabCase'
+import LocationOnIcon from '@material-ui/icons/LocationOn';
+import TripOriginIcon from '@material-ui/icons/TripOrigin';
+
+import Selector from './Selector'
+import {StationLookup} from '../utils/types'
+import {OptionalStationName} from '../store/types'
+import stationsLookup from '../data/stations.json'
+
+import useStyles from './StationSelectors.styles'
+
+
+export type StationChange = (stationName: OptionalStationName) => void
+
+
+const STATIONS_LOOKUP = (stationsLookup as unknown) as StationLookup
+
+const STATIONS_SELECTOR_VALUES = Object.values(STATIONS_LOOKUP)
+  .map(({name, abbr}) => ({value: abbr as OptionalStationName, display: name}))
+
+interface StationSelectorProps {
+  label: string;
+  station: OptionalStationName;
+  icon: ReactNode;
+  onChange: StationChange;
+}
+const StationSelector = ({label, station, icon, onChange}: StationSelectorProps) => {
+  const classes = useStyles()
+  const values = [
+    { value: '' as OptionalStationName, display: '' },
+    ...STATIONS_SELECTOR_VALUES,
+  ]
+
+  const selector = Selector<OptionalStationName>({
+    id: kebabCase(`${label}-station-selector`),
+    label,
+    value: station,
+    values,
+    onChange,
+  })
+
+  return (
+    <div className={classes.selector}>
+      <span className={classes.selectorIcon}>
+        {icon}
+      </span>
+      {selector}
+    </div>
+  )
+}
+
+interface Props {
+  origin: OptionalStationName;
+  onOriginChange: StationChange;
+  destination: OptionalStationName;
+  onDestinationChange: StationChange;
+}
+
+const StationSelectors = ({
+  origin,
+  onOriginChange,
+  destination,
+  onDestinationChange,
+}: Props) => {
+  const classes = useStyles()
+
+  return (
+    <section className={classes.root}>
+      <StationSelector
+        label="Origin"
+        station={origin}
+        icon={<TripOriginIcon />}
+        onChange={onOriginChange}
+      />
+      <StationSelector
+        label="Destination"
+        station={destination}
+        icon={<LocationOnIcon />}
+        onChange={onDestinationChange}
+      />
+    </section>
+  )
+}
+
+export default StationSelectors

--- a/src/components/StationSelectors.tsx
+++ b/src/components/StationSelectors.tsx
@@ -1,7 +1,10 @@
 import React, {ReactNode} from 'react'
 import kebabCase from 'lodash/kebabCase'
-import LocationOnIcon from '@material-ui/icons/LocationOn';
-import TripOriginIcon from '@material-ui/icons/TripOrigin';
+
+import IconButton from '@material-ui/core/IconButton';
+import LocationOnIcon from '@material-ui/icons/LocationOn'
+import TripOriginIcon from '@material-ui/icons/TripOrigin'
+import SyncIcon from '@material-ui/icons/Sync'
 
 import Selector from './Selector'
 import {StationLookup} from '../utils/types'
@@ -11,7 +14,7 @@ import stationsLookup from '../data/stations.json'
 import useStyles from './StationSelectors.styles'
 
 
-export type StationChange = (stationName: OptionalStationName) => void
+type StationChange = (stationName: OptionalStationName) => void
 
 
 const STATIONS_LOOKUP = (stationsLookup as unknown) as StationLookup
@@ -50,35 +53,51 @@ const StationSelector = ({label, station, icon, onChange}: StationSelectorProps)
   )
 }
 
+
+export type StationsChange = (
+  {origin, destination}: {origin: OptionalStationName, destination: OptionalStationName}
+) => void
+
 interface Props {
   origin: OptionalStationName;
-  onOriginChange: StationChange;
   destination: OptionalStationName;
-  onDestinationChange: StationChange;
+  onStationsChange: StationsChange
 }
 
 const StationSelectors = ({
   origin,
-  onOriginChange,
   destination,
-  onDestinationChange,
+  onStationsChange,
 }: Props) => {
   const classes = useStyles()
+  const onOriginChange = (newOrigin: OptionalStationName) => onStationsChange({origin: newOrigin, destination})
+  const onDestinationChange = (newDestination: OptionalStationName) => onStationsChange({origin, destination: newDestination})
+  const onStationSwap = () => onStationsChange({origin: destination, destination: origin})
 
   return (
     <section className={classes.root}>
-      <StationSelector
-        label="Origin"
-        station={origin}
-        icon={<TripOriginIcon />}
-        onChange={onOriginChange}
-      />
-      <StationSelector
-        label="Destination"
-        station={destination}
-        icon={<LocationOnIcon />}
-        onChange={onDestinationChange}
-      />
+      <div className={classes.selectors}>
+        <StationSelector
+          label="Origin"
+          station={origin}
+          icon={<TripOriginIcon />}
+          onChange={onOriginChange}
+        />
+        <StationSelector
+          label="Destination"
+          station={destination}
+          icon={<LocationOnIcon />}
+          onChange={onDestinationChange}
+        />
+      </div>
+      <IconButton
+        color="secondary"
+        className={classes.swapButton}
+        aria-label="Swap stations"
+        onClick={onStationSwap}
+      >
+        <SyncIcon />
+      </IconButton>
     </section>
   )
 }

--- a/src/containers/ConnectedRoutesPage.tsx
+++ b/src/containers/ConnectedRoutesPage.tsx
@@ -1,8 +1,7 @@
 import {connect} from 'react-redux'
 import {
-  setOrigin, 
-  setDestination, 
-  getSalmonInfo, 
+  setStations,
+  getSalmonInfo,
 } from '../store/actions'
 import {AppState} from '../store/reducers'
 import RoutesPage from '../components/RoutesPage'
@@ -26,8 +25,7 @@ const _mapStateToProps = ({
 })
 
 const _mapDispatchToProps = {
-  setOrigin,
-  setDestination,
+  setStations,
   getSalmonInfo,
 }
 

--- a/src/store/actions.test.ts
+++ b/src/store/actions.test.ts
@@ -1,4 +1,4 @@
-import { setOrigin, setDestination, setNumSalmonRoutes, getSalmonInfo } from './actions'
+import { setStations, setNumSalmonRoutes, getSalmonInfo } from './actions'
 import { AppState } from './reducers'
 import { StationName } from '../utils/types'
 
@@ -15,38 +15,19 @@ const MOCK_APP_STATE: AppState = ({
 })
 const MOCK_GET_STATE = () => MOCK_APP_STATE
 
-describe('setOrigin', () => {
-  it('dispatches SET_ORIGIN action w/ specified station', async () => {
-    let mockDispatch = jest.fn()
-    let name = 'WDUB' as StationName
-    let asyncAction = setOrigin(name)
+describe('setStations', () => {
+  it('dispatches SET_STATIONS action w/ specified origin/destination', async () => {
+    const mockDispatch = jest.fn()
+    const origin: StationName = 'WDUB'
+    const destination: StationName = 'NCON'
+    const asyncAction = setStations({ origin, destination })
 
     await asyncAction(mockDispatch, MOCK_GET_STATE, null)
 
     expect(mockDispatch).toHaveBeenCalledTimes(2)
     expect(mockDispatch).toHaveBeenCalledWith({
-      type: 'SET_ORIGIN',
-      payload: name,
-    })
-  })
-
-  it('dispatches getSalmonInfo action', () => {
-    // TODO
-  })
-})
-
-describe('setDestination', () => {
-  it('returns SET_DESTINATION action w/ specified station', async () => {
-    let mockDispatch = jest.fn()
-    let name = 'NCON' as StationName
-    let asyncAction = setDestination(name)
-
-    await asyncAction(mockDispatch, MOCK_GET_STATE, undefined)
-
-    expect(mockDispatch).toHaveBeenCalledTimes(2)
-    expect(mockDispatch).toHaveBeenCalledWith({
-      type: 'SET_DESTINATION',
-      payload: name,
+      type: 'SET_STATIONS',
+      payload: { origin, destination },
     })
   })
 

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -74,22 +74,15 @@ export const getSalmonInfo = (): ThunkResult<void> => async (
   }
 }
 
-export const setOrigin = (name: OptionalStationName): ThunkResult<void> => (
-  dispatch,
-) => {
+export const setStations = (
+  { origin, destination }: { origin: OptionalStationName, destination: OptionalStationName },
+): ThunkResult<void> => (dispatch) => {
   dispatch({
-    type: 'SET_ORIGIN',
-    payload: name,
-  })
-  dispatch(getSalmonInfo())
-}
-
-export const setDestination = (name: OptionalStationName): ThunkResult<void> => (
-  dispatch,
-) => {
-  dispatch({
-    type: 'SET_DESTINATION',
-    payload: name,
+    type: 'SET_STATIONS',
+    payload: {
+      origin,
+      destination,
+    },
   })
   dispatch(getSalmonInfo())
 }

--- a/src/store/reducers.test.ts
+++ b/src/store/reducers.test.ts
@@ -1,7 +1,7 @@
 import rootReducer, { AppState } from './reducers'
 import { StationName, SalmonRoute, Train } from '../utils/types'
 
-const INITIAL_STATE = {
+const INITIAL_STATE: AppState = {
   origin: 'BALB',
   destination: '12TH',
   numSalmonRoutes: 5,
@@ -10,8 +10,8 @@ const INITIAL_STATE = {
   salmonRoutes: [],
   arrivals: [],
   numArrivals: 3,
-} as AppState
-const SAMPLE_ROUTES = [
+}
+const SAMPLE_ROUTES: SalmonRoute[] = [
   {
     backwardsRideTime: 5,
     backwardsRouteId: 'ROUTE 3',
@@ -45,8 +45,8 @@ const SAMPLE_ROUTES = [
     },
     waitTime: 2,
   },
-] as SalmonRoute[]
-const SAMPLE_ARRIVALS = [
+]
+const SAMPLE_ARRIVALS: Train[] = [
   {
     abbreviation: '24TH',
     bikeflag: 1,
@@ -107,43 +107,31 @@ const SAMPLE_ARRIVALS = [
     minutes: 40,
     platform: 2,
   },
-] as Train[]
+]
 
-it('should handle SET_ORIGIN action', () => {
-  let name = 'SFIA'
-  let actualState = rootReducer(INITIAL_STATE, {
-    type: 'SET_ORIGIN',
-    payload: name,
+it('should handle SET_STATIONS action', () => {
+  const origin: StationName = 'MONT'
+  const destination: StationName = 'PITT'
+  const actualState = rootReducer(INITIAL_STATE, {
+    type: 'SET_STATIONS',
+    payload: { origin, destination },
   })
-  let expectedState = {
+  const expectedState = {
     ...INITIAL_STATE,
-    origin: name,
-  }
-
-  expect(actualState).toEqual(expectedState)
-})
-
-it('should handle SET_DESTINATION action', () => {
-  let name = 'PITT' as StationName
-  let actualState = rootReducer(INITIAL_STATE, {
-    type: 'SET_DESTINATION',
-    payload: name,
-  })
-  let expectedState = {
-    ...INITIAL_STATE,
-    destination: name,
+    origin,
+    destination,
   }
 
   expect(actualState).toEqual(expectedState)
 })
 
 it('should handle SET_NUM_SALMON_ROUTES action', () => {
-  let numRoutes = 10
-  let actualState = rootReducer(INITIAL_STATE, {
+  const numRoutes = 10
+  const actualState = rootReducer(INITIAL_STATE, {
     type: 'SET_NUM_SALMON_ROUTES',
     payload: numRoutes,
   })
-  let expectedState = {
+  const expectedState = {
     ...INITIAL_STATE,
     numSalmonRoutes: numRoutes,
   }
@@ -152,12 +140,12 @@ it('should handle SET_NUM_SALMON_ROUTES action', () => {
 })
 
 it('should handle SET_RISKINESS_FACTOR action', () => {
-  let riskinessFactor = 2
-  let actualState = rootReducer(INITIAL_STATE, {
+  const riskinessFactor = 2
+  const actualState = rootReducer(INITIAL_STATE, {
     type: 'SET_RISKINESS_FACTOR',
     payload: riskinessFactor,
   })
-  let expectedState = {
+  const expectedState = {
     ...INITIAL_STATE,
     riskinessFactor,
   }
@@ -166,8 +154,8 @@ it('should handle SET_RISKINESS_FACTOR action', () => {
 })
 
 it('should handle FETCH_SALMON_INFO action', () => {
-  let actualState = rootReducer(INITIAL_STATE, { type: 'FETCH_SALMON_INFO' })
-  let expectedState = {
+  const actualState = rootReducer(INITIAL_STATE, { type: 'FETCH_SALMON_INFO' })
+  const expectedState = {
     ...INITIAL_STATE,
     isFetching: true,
   }
@@ -176,9 +164,9 @@ it('should handle FETCH_SALMON_INFO action', () => {
 })
 
 it('should handle RECEIVE_SALMON_INFO action', () => {
-  let routes = SAMPLE_ROUTES
-  let arrivals = SAMPLE_ARRIVALS
-  let actualState = rootReducer(
+  const routes = SAMPLE_ROUTES
+  const arrivals = SAMPLE_ARRIVALS
+  const actualState = rootReducer(
     {
       ...INITIAL_STATE,
       isFetching: true,
@@ -188,7 +176,7 @@ it('should handle RECEIVE_SALMON_INFO action', () => {
       payload: { routes, arrivals },
     },
   )
-  let expectedState = {
+  const expectedState = {
     ...INITIAL_STATE,
     arrivals,
     salmonRoutes: routes,
@@ -199,7 +187,7 @@ it('should handle RECEIVE_SALMON_INFO action', () => {
 })
 
 it('should handle ERROR_SALMON_INFO action', () => {
-  let actualState = rootReducer(
+  const actualState = rootReducer(
     {
       ...INITIAL_STATE,
       isFetching: true,
@@ -209,7 +197,7 @@ it('should handle ERROR_SALMON_INFO action', () => {
       error: new Error('test error'),
     },
   )
-  let expectedState = {
+  const expectedState = {
     ...INITIAL_STATE,
     salmonRoutes: [],
     arrivals: [],
@@ -220,12 +208,12 @@ it('should handle ERROR_SALMON_INFO action', () => {
 })
 
 it('should handle SET_NUM_ARRIVALS action', () => {
-  let numArrivals = 10
-  let actualState = rootReducer(INITIAL_STATE, {
+  const numArrivals = 10
+  const actualState = rootReducer(INITIAL_STATE, {
     type: 'SET_NUM_ARRIVALS',
     payload: numArrivals,
   })
-  let expectedState = {
+  const expectedState = {
     ...INITIAL_STATE,
     numArrivals,
   }

--- a/src/store/reducers.ts
+++ b/src/store/reducers.ts
@@ -12,8 +12,8 @@ const origin = (
 ): OptionalStationName => {
   let newState = state
 
-  if (action.type === 'SET_ORIGIN') {
-    newState = action.payload
+  if (action.type === 'SET_STATIONS') {
+    newState = action.payload.origin
   }
 
   return newState
@@ -25,8 +25,8 @@ const destination = (
 ): OptionalStationName => {
   let newState = state
 
-  if (action.type === 'SET_DESTINATION') {
-    newState = action.payload
+  if (action.type === 'SET_STATIONS') {
+    newState = action.payload.destination
   }
 
   return newState

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -6,13 +6,12 @@ import {
 
 export type OptionalStationName = '' | StationName
 
-interface SetOriginAction {
-  type: 'SET_ORIGIN';
-  payload: OptionalStationName;
-}
-interface SetDestination {
-  type: 'SET_DESTINATION';
-  payload: OptionalStationName;
+interface SetStations {
+  type: 'SET_STATIONS';
+  payload: {
+    origin: OptionalStationName;
+    destination: OptionalStationName;
+  }
 }
 interface SetNumSalmonRoutes {
   type: 'SET_NUM_SALMON_ROUTES';
@@ -41,8 +40,7 @@ interface SetNumArrivals {
   payload: number;
 }
 
-export type AppAction = SetOriginAction
-  | SetDestination
+export type AppAction = SetStations
   | SetNumSalmonRoutes
   | FetchSalmonInfo
   | ReceiveSalmonInfo


### PR DESCRIPTION
Adding a button to allow for swapping origin and destination stations in newly created `StationsSelector` component

<img width="470" alt="Screen Shot 2019-10-30 at 7 06 44 PM" src="https://user-images.githubusercontent.com/5714478/67912891-98b92b80-fb48-11e9-9654-6c7ce277024b.png">

As a result, I updated the Redux actions. Folded `'SET_ORIGIN'` & `'SET_DESTINATION'` to `'SET_STATIONS'`.

Fixes #15 & #30 