### PR TITLE
Update salmon routes UI

### DIFF
--- a/src/components/RoutesPage.tsx
+++ b/src/components/RoutesPage.tsx
@@ -41,6 +41,7 @@ const LastUpdatedMessage = (
         <IconButton
           color="secondary"
           aria-label="Refresh salmon routes"
+          size="small"
           onClick={onRefresh}
         >
           <RefreshIcon />

--- a/src/components/SalmonRoutes.styles.ts
+++ b/src/components/SalmonRoutes.styles.ts
@@ -1,83 +1,18 @@
-import {CSSProperties} from 'react';
-import {gridSize, gutterSize} from '../styling'
+import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 
-const STATION_COLUMN_STYLES = {
-  width: gridSize(4),
-}
-const ROUTE_COLUMN_STYLES = {
-  width: gridSize(5),
-}
-const TIME_COLUMN_STYLES = {
-  width: gridSize(3),
-}
-
-const HEADER_CELL_STYLES = {
-  textAlign: 'center',
-  color: '#fff',
-  padding: gutterSize(1),
-}
-
-export default {
-  header: {
-    display: 'flex',
-    backgroundColor: '#222',
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-  } as CSSProperties,
-  headerStation: {
-    ...HEADER_CELL_STYLES,
-    ...STATION_COLUMN_STYLES,
-  } as CSSProperties,
-  headerRoute: {
-    ...HEADER_CELL_STYLES,
-    ...ROUTE_COLUMN_STYLES,
-  } as CSSProperties,
-  headerTime: {
-    ...HEADER_CELL_STYLES,
-    ...TIME_COLUMN_STYLES,
-  } as CSSProperties,
-  salmonRoute: {
-    display: 'flex',
-    backgroundColor: '#eee',
-    marginBottom: 1,
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    borderRadius: 5,
-  } as CSSProperties,
-  station: {
-    ...STATION_COLUMN_STYLES,
-    fontSize: 25,
-    textAlign: 'center',
-    letterSpacing: -2,
-    // numberOfLines: 2,
-  } as CSSProperties,
-  route: {
-    ...ROUTE_COLUMN_STYLES,
-  } as CSSProperties,
-  routeDir: {
-    textAlign: 'center',
-    // numberOfLines: 1,
-    // ellipsizeMode: 'middle',
-  } as CSSProperties,
-  routeDivider: {
-    borderWidth: 1,
-    borderStyle: 'solid',
-    borderColor: '#fff',
-    marginTop: gutterSize(1),
-    marginBottom: gutterSize(1),
-  } as CSSProperties,
-  time: {
-    ...TIME_COLUMN_STYLES,
-    padding: gutterSize(1),
-    textAlign: 'center',
-  } as CSSProperties,
-  timeValue: {
-    fontSize: 45,
-    // letterSpacing: -10
-  } as CSSProperties,
-  timeLabel: {
-    paddingLeft: gutterSize(1),
-  } as CSSProperties,
-}
+export default makeStyles((theme: Theme) => (
+  createStyles({
+    additionalTime: {
+      color: theme.palette.text.secondary,
+      paddingLeft: theme.spacing(1),
+    },
+    arrow: {
+      marginLeft: theme.spacing(2),
+      marginRight: theme.spacing(2),
+    },
+    stationArrow: {
+      marginLeft: theme.spacing(1),
+      marginRight: theme.spacing(1),
+    },
+  })
+))

--- a/src/components/SalmonRoutes.tsx
+++ b/src/components/SalmonRoutes.tsx
@@ -1,19 +1,52 @@
-import React, {FunctionComponent} from 'react'
+import React, {useState, ChangeEvent} from 'react'
+import Grid from '@material-ui/core/Grid'
+import Box from '@material-ui/core/Box'
+import Typography from '@material-ui/core/Typography'
+import Badge from '@material-ui/core/Badge'
+import Chip from '@material-ui/core/Chip'
+import ExpansionPanel from '@material-ui/core/ExpansionPanel'
+import ExpansionPanelDetails from '@material-ui/core/ExpansionPanelDetails'
+import ExpansionPanelSummary from '@material-ui/core/ExpansionPanelSummary'
+import ExpandMoreIcon from '@material-ui/icons/ExpandMore'
+import TrainIcon from '@material-ui/icons/Train'
+import PanToolIcon from '@material-ui/icons/PanTool'
+import TransferWithinAStationIcon from '@material-ui/icons/TransferWithinAStation'
+import ChevronRightIcon from '@material-ui/icons/ChevronRight'
 import stationsLookup from '../data/stations.json'
 import {getSalmonTimeFromRoute} from '../utils/salmon'
 import {Train, SalmonRoute as SalmonRouteData} from '../utils/types'
 
-import styles from './SalmonRoutes.styles'
+import useStyles from './SalmonRoutes.styles'
+
+interface WaitBadgeProps {
+  waitTime: number;
+  lateMessage: string;
+}
+
+const WaitBadge = ({waitTime, lateMessage}: WaitBadgeProps) => (
+  <Badge
+    badgeContent={waitTime <= 0 ? lateMessage : waitTime}
+    color={waitTime <= 0 ? 'secondary' : 'primary'}
+    anchorOrigin={{horizontal: 'right', vertical: 'bottom'}}
+  >
+    <PanToolIcon />
+  </Badge>
+)
 
 interface SalmonRouteProps {
   route: SalmonRouteData;
   nextTrain: Train;
+  isExpanded: boolean;
+  onChange: (event: ChangeEvent<{}>, isExpanded: boolean) => void;
 }
 
-const SalmonRoute: FunctionComponent<{route: SalmonRouteData, nextTrain: Train}> = ({
-  route, 
+const SalmonRoute = ({
+  route,
   nextTrain,
-}) => {
+  isExpanded,
+  onChange,
+}: SalmonRouteProps) => {
+  const classes = useStyles()
   const {
     waitTime,
     backwardsTrain,
@@ -23,8 +56,9 @@ const SalmonRoute: FunctionComponent<{route: SalmonRouteData, nextTrain: Train}>
   } = route
   const salmonTime = getSalmonTimeFromRoute(route)
   const backwardsStationInfo = stationsLookup[backwardsStation]
-  const backwardsStationName = backwardsStationInfo.name.toUpperCase()
+  const backwardsStationName = backwardsStationInfo.name
   let salmonTimeAdditionalTime = salmonTime
+
 
   if (nextTrain) {
     // Make sure the minimal time is 0
@@ -36,41 +70,50 @@ const SalmonRoute: FunctionComponent<{route: SalmonRouteData, nextTrain: Train}>
     )
   }
 
-  const minutesLabel = salmonTimeAdditionalTime === 1 ? 'min' : 'mins'
-  const additiveDisplay = salmonTimeAdditionalTime > 0 ? '⁺' : undefined
+  const additionalSalmonTimeDisplay = salmonTimeAdditionalTime > 0 ? `+${salmonTimeAdditionalTime}` : '——'
 
   return (
-    <div style={styles.salmonRoute}>
-      <span style={styles.station}>
-        {backwardsStationName}
-      </span>
-      <div style={styles.route}>
-        <span style={styles.routeDir}>
-          {backwardsTrain.destination} in {waitTime}
-        </span>
-        <div style={styles.routeDivider} />
-        <span style={styles.routeDir}>
-          {backwardsWaitTime} for {returnTrain.destination}
-        </span>
-      </div>
-      <div style={styles.time}>
-        <span style={styles.timeValue}>
-          {additiveDisplay}
-          {salmonTimeAdditionalTime}
-        </span>
-        <span style={styles.timeLabel}>{minutesLabel}</span>
-      </div>
-    </div>
+    <ExpansionPanel expanded={isExpanded} onChange={onChange}>
+      <ExpansionPanelSummary expandIcon={<ExpandMoreIcon />}>
+        <Grid container justify="space-between" alignItems="center" wrap="nowrap">
+          <Grid item xs={9}>
+            <Typography variant="h5" component="span">
+              {backwardsStationName}
+            </Typography>
+          </Grid>
+          <Grid item xs={3}>
+            <Typography variant="h5" component="span" className={classes.additionalTime}>
+              {additionalSalmonTimeDisplay}
+            </Typography>
+          </Grid>
+        </Grid>
+      </ExpansionPanelSummary>
+      <ExpansionPanelDetails>
+        <Box flex="1">
+          <Box mb={3} display="flex" alignItems="center">
+            <WaitBadge waitTime={waitTime} lateMessage="Now" />
+            <ChevronRightIcon className={classes.arrow} />
+            <Chip icon={<TrainIcon />} label={backwardsTrain.destination} />
+          </Box>
+          <Box display="flex" alignItems="center">
+            <TransferWithinAStationIcon fontSize="large" />
+            <ChevronRightIcon className={classes.stationArrow} />
+            <Chip
+              variant="outlined"
+              label={backwardsStationInfo.name}
+              className={classes.train}
+            />
+          </Box>
+          <Box mt={3} display="flex" alignItems="center">
+            <WaitBadge waitTime={backwardsWaitTime} lateMessage="<1" />
+            <ChevronRightIcon className={classes.arrow} />
+            <Chip icon={<TrainIcon />} label={`${returnTrain.destination} — ${returnTrain.length}-car`} className={classes.train} />
+          </Box>
+        </Box>
+      </ExpansionPanelDetails>
+    </ExpansionPanel>
   )
 }
-
-const Header: FunctionComponent<{}> = () => (
-  <h2 style={styles.header}>
-    <span style={styles.headerStation}>Swim To</span>
-    <span style={styles.headerRoute}>Route</span>
-    <span style={styles.headerTime}>Add</span>
-  </h2>
-)
 
 interface Props {
   routes: SalmonRouteData[];
@@ -78,23 +121,36 @@ interface Props {
   nextTrain: Train;
 }
 
-const SalmonRoutes: FunctionComponent<Props> = ({
+const SalmonRoutes = ({
   routes,
   numRoutes,
   nextTrain,
-}) => {
+}: Props) => {
+  const [expandedRouteIndex, setExpandRouteIndex] = useState(-1)
+
+  const handleExpandedChange = (panelIndex: number) => (
+    (event: ChangeEvent<{}>, isExpanded: boolean) => {
+      setExpandRouteIndex(isExpanded ? panelIndex : -1)
+    }
+  )
+
   // TODO: Salmon routes need some sort of unique identifier
   const salmonRoutes = routes
     .map((route, index) => (
-      <SalmonRoute key={index} route={route} nextTrain={nextTrain} />
+      <SalmonRoute
+        key={index}
+        route={route}
+        nextTrain={nextTrain}
+        isExpanded={index === expandedRouteIndex}
+        onChange={handleExpandedChange(index)}
+      />
     ))
     .slice(0, numRoutes)
 
   return (
-    <div>
-      <Header />
+    <Box>
       {salmonRoutes}
-    </div>
+    </Box>
   )
 }
 

--- a/src/components/SalmonRoutes.tsx
+++ b/src/components/SalmonRoutes.tsx
@@ -101,13 +101,15 @@ const SalmonRoute = ({
             <Chip
               variant="outlined"
               label={backwardsStationInfo.name}
-              className={classes.train}
             />
           </Box>
           <Box mt={3} display="flex" alignItems="center">
             <WaitBadge waitTime={backwardsWaitTime} lateMessage="<1" />
             <ChevronRightIcon className={classes.arrow} />
-            <Chip icon={<TrainIcon />} label={`${returnTrain.destination} — ${returnTrain.length}-car`} className={classes.train} />
+            <Chip
+              icon={<TrainIcon />}
+              label={`${returnTrain.destination} — ${returnTrain.length}-car`}
+            />
           </Box>
         </Box>
       </ExpansionPanelDetails>


### PR DESCRIPTION
## Problem

The salmon routes UI was the quick & dirty UI I built early on to iterate on the algorithm and test it out in the wild. It has wrapping problems, is missing the number of trains, and just wasn't visually appealing.

## Solution

Completely restyled the salmon routes UI to fix all the wrapping problems and to make it more visually appealing. Also made full use of [`material-ui`'s](https://material-ui.com/) component library and css-in-js [styling solution](https://material-ui.com/styles/basics/). The route UI is now an [`ExpansionPanel`](https://material-ui.com/components/expansion-panels/), using [`Box`](https://material-ui.com/components/box/) & [`Grid`](https://material-ui.com/components/grid/) to layout the UI. Wordy text has been replaced by [`Badge`s](https://material-ui.com/components/badges/), [`Chip`s](https://material-ui.com/components/chips/), and [iconography](https://material-ui.com/components/material-icons/). This allowed me to greatly simplify & limit the CSS used.

The backwards (aka salmon) station and the additional time taking the route are the two most important pieces of information and are what are shown for every route in the expansion panels. You must tap into a given panel to expose the backwards train, the returning train and the wait times for each. Only one set of details will show at a time, making the expansion panels act more like an accordion.

I also made the refresh button at the top size `'small'` so that it doesn't take up as much height.

NOTE: The [`Arrivals` section](https://github.com/benmvp/bart-salmon/blob/master/src/components/Arrivals.tsx) in the middle will be updated in a follow-up PR.

## Screenshots

| Before | After |
| ------ | ----- |
| <img width="380" alt="Screen Shot 2019-11-21 at 10 31 23 PM" src="https://user-images.githubusercontent.com/5714478/69403175-c2302780-0cae-11ea-9bc9-6ce726b4cabf.png"> | <img width="378" alt="Screen Shot 2019-11-21 at 10 22 46 PM" src="https://user-images.githubusercontent.com/5714478/69402831-e2abb200-0cad-11ea-8e0b-b2fa27db7f0b.png"> |

## Issues

Fixes #3 & fixes #13 