### PR TITLE
Update Arrivals UI + all-around cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,16 +22,12 @@ Then, start the app:
 npm start
 ```
 
-```sh
-npm install --save react-composite-events
-```
-
 ## Technologies used
 
 Bart Salmon is a mobile web, aiming to provide a useful service as well as an opportunity to learn new technologies:
 
 - **UI:** [React](https://facebook.github.io/react/)
-- **Styling:** [Material UI](https://material-ui.com/) + Inline CSS
+- **Styling:** [Material UI](https://material-ui.com/)
 - **Data Flow:** [Lodash](https://lodash.com/) & [Redux](http://redux.js.org/) (w/ [Redux Thunk](https://github.com/gaearon/redux-thunk) & [Async Functions](https://github.com/tc39/ecmascript-asyncawait))
 - **API:** [Bart API](http://api.bart.gov/docs/overview/index.aspx)
 - **Build Tooling:** [Create React App](https://github.com/facebookincubator/create-react-app)

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,19 +1,19 @@
-// import keyBy from 'lodash/keyBy'
-// import { fetchBartInfo } from './bart'
-// import { EtdsApiRequest } from './types'
-// import { EtdsLookup } from '../utils/types'
-
-
-// export const getEstimatedTimesOfDeparture = (): Promise<EtdsLookup> =>
-//   fetchBartInfo<EtdsApiRequest>({
-//     type: 'etd',
-//     command: 'etd',
-//     params: { orig: 'ALL' }
-//   }).then((respJson) => keyBy(respJson.station, 'abbr'))
-
+import keyBy from 'lodash/keyBy'
+import { fetchBartInfo } from './bart'
+import { EtdsApiRequest } from './types'
 import { EtdsLookup } from '../utils/types'
-import etds from './__mocks__/etds-rush-pm-off-by-one.json'
 
-export const getEstimatedTimesOfDeparture = (): Promise<EtdsLookup> => Promise.resolve(
-  (etds as unknown) as EtdsLookup
-)
+
+export const getEstimatedTimesOfDeparture = (): Promise<EtdsLookup> =>
+  fetchBartInfo<EtdsApiRequest>({
+    type: 'etd',
+    command: 'etd',
+    params: { orig: 'ALL' }
+  }).then((respJson) => keyBy(respJson.station, 'abbr'))
+
+// import { EtdsLookup } from '../utils/types'
+// import etds from './__mocks__/etds-rush-pm-off-by-one.json'
+
+// export const getEstimatedTimesOfDeparture = (): Promise<EtdsLookup> => Promise.resolve(
+//   (etds as unknown) as EtdsLookup
+// )

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,19 +1,19 @@
-import keyBy from 'lodash/keyBy'
-import { fetchBartInfo } from './bart'
-import { EtdsApiRequest } from './types'
-import { EtdsLookup } from '../utils/types'
-
-
-export const getEstimatedTimesOfDeparture = (): Promise<EtdsLookup> =>
-  fetchBartInfo<EtdsApiRequest>({
-    type: 'etd',
-    command: 'etd',
-    params: { orig: 'ALL' }
-  }).then((respJson) => keyBy(respJson.station, 'abbr'))
-
+// import keyBy from 'lodash/keyBy'
+// import { fetchBartInfo } from './bart'
+// import { EtdsApiRequest } from './types'
 // import { EtdsLookup } from '../utils/types'
-// import etds from './__mocks__/etds-rush-pm-off-by-one.json'
 
-// export const getEstimatedTimesOfDeparture = (): Promise<EtdsLookup> => Promise.resolve(
-//   (etds as unknown) as EtdsLookup
-// )
+
+// export const getEstimatedTimesOfDeparture = (): Promise<EtdsLookup> =>
+//   fetchBartInfo<EtdsApiRequest>({
+//     type: 'etd',
+//     command: 'etd',
+//     params: { orig: 'ALL' }
+//   }).then((respJson) => keyBy(respJson.station, 'abbr'))
+
+import { EtdsLookup } from '../utils/types'
+import etds from './__mocks__/etds-rush-pm-off-by-one.json'
+
+export const getEstimatedTimesOfDeparture = (): Promise<EtdsLookup> => Promise.resolve(
+  (etds as unknown) as EtdsLookup
+)

--- a/src/components/Arrivals.styles.ts
+++ b/src/components/Arrivals.styles.ts
@@ -1,40 +1,13 @@
-import {CSSProperties} from 'react'
-import {gridSize, gutterSize} from '../styling'
+import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 
-export default {
-  root: {
-    display: 'flex',
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-  } as CSSProperties,
-  headingSection: {
-    display: 'flex',
-    flexDirection: 'column',
-    paddingLeft: gutterSize(3),
-    width: gridSize(4),
-  } as CSSProperties,
-  headingNextTrain: {
-    textAlign: 'right',
-  } as CSSProperties,
-  headingDestination: {
-    textAlign: 'right',
-    // numberOfLines: 1,
-    // ellipsizeMode: 'middle',
-  } as CSSProperties,
-  nextTrain: {
-    width: gridSize(3),
-    flex: 1,
-  } as CSSProperties,
-  nextTrainTime: {
-    fontSize: 84,
-    textAlign: 'center',
-  } as CSSProperties,
-  followingTrains: {
-    display: 'flex',
-    flexDirection: 'column',
-    paddingRight: gutterSize(3),
-    width: gridSize(3),
-  } as CSSProperties,
-  followingTrainTime: {} as CSSProperties,
-}
+export default makeStyles((theme: Theme) => (
+  createStyles({
+    heading: {
+      marginLeft: theme.spacing(1),
+    },
+    trainBubble: {
+      marginRight: theme.spacing(1),
+      marginBottom: theme.spacing(1),
+    },
+  })
+))

--- a/src/components/Arrivals.tsx
+++ b/src/components/Arrivals.tsx
@@ -23,7 +23,7 @@ const ArrivingTrains =  ({trains, numArrivals}: {trains: Train[], numArrivals: n
   )).slice(0, numArrivals)
 
   return (
-    <Box px={3} mb={2}>
+    <Box px={3} mb={2} textAlign="center">
       {trainBubbles}
     </Box>
   )

--- a/src/components/Arrivals.tsx
+++ b/src/components/Arrivals.tsx
@@ -1,36 +1,32 @@
-import React, {FunctionComponent} from 'react'
+import React from 'react'
+import Box from '@material-ui/core/Box'
+import Typography from '@material-ui/core/Typography'
+import Chip from '@material-ui/core/Chip'
+import DepartureBoardIcon from '@material-ui/icons/DepartureBoard'
 import {Train} from '../utils/types'
 import {OptionalStationName} from '../store/types'
 import stationsLookup from '../data/stations.json'
 
-import styles from './Arrivals.styles'
+import useStyles from './Arrivals.styles'
 
 
-const _displayMinutes = (minutes: number): string =>
-  `${minutes} ${minutes === 1 ? 'min' : 'mins'}`
-
-const NextTrain: FunctionComponent<{train?: Train}> = ({train}) => {
-  if (!train) {
-    return null
-  }
-
-  const {minutes} = train
+const ArrivingTrains =  ({trains, numArrivals}: {trains: Train[], numArrivals: number}) => {
+  const classes = useStyles()
+  const trainBubbles = trains.map(({minutes, destination}, index) => (
+    <Chip
+      key={index}
+      label={`${minutes} — ${destination}`}
+      color={index === 0 ? 'primary' : undefined}
+      variant={index === 0 ? undefined : 'outlined'}
+      className={classes.trainBubble}
+    />
+  )).slice(0, numArrivals)
 
   return (
-    <div style={styles.nextTrain}>
-      <div style={styles.nextTrainTime}>{minutes}</div>
-    </div>
+    <Box px={3} mb={2}>
+      {trainBubbles}
+    </Box>
   )
-}
-
-const FollowingTrains: FunctionComponent<{trains: Train[]}> = ({trains}) => {
-  const trainComponents = trains.map(({minutes}, index) => (
-    <span key={index} style={styles.followingTrainTime}>
-      {_displayMinutes(minutes)}
-    </span>
-  ))
-
-  return <div style={styles.followingTrains}>{trainComponents}</div>
 }
 
 interface Props {
@@ -39,25 +35,24 @@ interface Props {
   numArrivals: number;
 }
 
-const Arrivals: FunctionComponent<Props> = ({
-  destination, 
+const Arrivals = ({
+  destination,
   arrivals,
   numArrivals,
-}) => {
-  const [firstTrain, ...followingTrains] = arrivals.slice(0, numArrivals)
+}: Props) => {
+  const classes = useStyles()
   const destinationDisplay = destination && stationsLookup[destination].name
 
   return (
-    <div style={styles.root}>
-      <div style={styles.headingSection}>
-        <span style={styles.headingNextTrain}>Next train to</span>
-        <span style={styles.headingDestination}>
-          {destinationDisplay}
-        </span>
-      </div>
-      <NextTrain train={firstTrain} />
-      <FollowingTrains trains={followingTrains} />
-    </div>
+    <Box>
+      <Box px={2} pb={0.5} mb={1} display="flex">
+        <DepartureBoardIcon />
+        <Typography variant="subtitle1" component="h2" className={classes.heading}>
+          Times for trains to {destinationDisplay}:
+        </Typography>
+      </Box>
+      <ArrivingTrains trains={arrivals} numArrivals={numArrivals} />
+    </Box>
   )
 }
 

--- a/src/components/RoutesPage.styles.ts
+++ b/src/components/RoutesPage.styles.ts
@@ -1,7 +1,4 @@
 import { makeStyles } from '@material-ui/core/styles';
 
 export default makeStyles({
-  lastUpdatedShell: {
-    textAlign: 'center',
-  },
 })

--- a/src/components/RoutesPage.tsx
+++ b/src/components/RoutesPage.tsx
@@ -4,6 +4,7 @@ import formatDate from 'date-fns/format';
 
 import Box from '@material-ui/core/Box'
 import Typography from '@material-ui/core/Typography';
+import Link from '@material-ui/core/Link';
 import IconButton from '@material-ui/core/IconButton';
 import Divider from '@material-ui/core/Divider';
 import RefreshIcon from '@material-ui/icons/Refresh'
@@ -122,6 +123,13 @@ const RoutesPage= ({
         <Divider variant="middle" />
       </Box>
       {arrivalsAndRoutes}
+      <Box mt={3}>
+        <Typography align="center" variant="caption" component="p">
+          Brought to you with&nbsp;
+          <span role="img" aria-label="love">❤️</span> by&nbsp;
+          <Link href="http://www.benmvp.com/" target="_blank" rel="noopener noreferrer">Ben Ilegbodu</Link>.
+        </Typography>
+      </Box>
     </Box>
   )
 }

--- a/src/components/RoutesPage.tsx
+++ b/src/components/RoutesPage.tsx
@@ -2,6 +2,7 @@ import React, {useEffect} from 'react'
 import isEmpty from 'lodash/isEmpty'
 import formatDate from 'date-fns/format';
 
+import Box from '@material-ui/core/Box'
 import Typography from '@material-ui/core/Typography';
 import IconButton from '@material-ui/core/IconButton';
 import Divider from '@material-ui/core/Divider';
@@ -13,8 +14,6 @@ import SalmonRoutes from './SalmonRoutes'
 import {SalmonRoute, Train} from '../utils/types'
 import {OptionalStationName} from '../store/types'
 
-import useStyles from './RoutesPage.styles'
-
 
 const LastUpdatedMessage = (
   {
@@ -25,8 +24,6 @@ const LastUpdatedMessage = (
     onRefresh: () => void,
   }
 ) => {
-  const classes = useStyles()
-
   if (!lastUpdated) {
     return null
   }
@@ -34,7 +31,7 @@ const LastUpdatedMessage = (
 
   return (
     <>
-      <div className={classes.lastUpdatedShell}>
+      <Box textAlign="center">
         <Typography display="inline" variant="body2"  color="textSecondary">
           Last updated {formatDate(lastUpdated, 'eee @ h:mma')}
         </Typography>
@@ -46,7 +43,7 @@ const LastUpdatedMessage = (
         >
           <RefreshIcon />
         </IconButton>
-      </div>
+      </Box>
       <Divider variant="middle" />
     </>
   )
@@ -95,34 +92,37 @@ const RoutesPage= ({
     )
     arrivalsAndRoutes = (
       <>
-        <div>
+        <Box component="section" mt={2}>
           <Arrivals
             destination={destination}
             arrivals={arrivals}
             numArrivals={numArrivals}
           />
-        </div>
-        <div>
+        </Box>
+        <Box component="section">
           <SalmonRoutes
             routes={salmonRoutes}
             numRoutes={numSalmonRoutes}
             nextTrain={nextTrain}
           />
-        </div>
+        </Box>
       </>
     )
   }
 
   return (
-    <div>
+    <Box component="main">
       {lastUpdatedMessage}
-      <StationSelectors
-        origin={origin}
-        destination={destination}
-        onStationsChange={setStations}
-      />
+      <Box my={2}>
+        <StationSelectors
+          origin={origin}
+          destination={destination}
+          onStationsChange={setStations}
+        />
+        <Divider variant="middle" />
+      </Box>
       {arrivalsAndRoutes}
-    </div>
+    </Box>
   )
 }
 

--- a/src/components/SalmonRoutes.styles.ts
+++ b/src/components/SalmonRoutes.styles.ts
@@ -3,7 +3,6 @@ import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 export default makeStyles((theme: Theme) => (
   createStyles({
     additionalTime: {
-      color: theme.palette.text.secondary,
       paddingLeft: theme.spacing(1),
     },
     arrow: {

--- a/src/components/StationSelectors.styles.ts
+++ b/src/components/StationSelectors.styles.ts
@@ -2,13 +2,6 @@ import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 
 export default makeStyles((theme: Theme) => (
   createStyles({
-    root: {
-      alignItems: 'center',
-      display: 'flex',
-      flexDirection: 'row',
-      justifyContent: 'space-between',
-      padding: theme.spacing(2),
-    },
     selectors: {
       flex: 1,
     },

--- a/src/components/StationSelectors.tsx
+++ b/src/components/StationSelectors.tsx
@@ -1,6 +1,7 @@
 import React, {ReactNode} from 'react'
 import kebabCase from 'lodash/kebabCase'
 
+import Box from '@material-ui/core/Box'
 import IconButton from '@material-ui/core/IconButton';
 import LocationOnIcon from '@material-ui/icons/LocationOn'
 import TripOriginIcon from '@material-ui/icons/TripOrigin'
@@ -75,7 +76,7 @@ const StationSelectors = ({
   const onStationSwap = () => onStationsChange({origin: destination, destination: origin})
 
   return (
-    <section className={classes.root}>
+    <Box component="section" px={2} display="flex" justifyContent="space-between" alignItems="center">
       <div className={classes.selectors}>
         <StationSelector
           label="Origin"
@@ -98,7 +99,7 @@ const StationSelectors = ({
       >
         <SwapVertIcon />
       </IconButton>
-    </section>
+    </Box>
   )
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -1,15 +1,4 @@
 body {
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-  color: #212121;
-  font-family: 'Helvetica Neue', 'Calibri Light', Roboto, sans-serif;
-  letter-spacing: 0.02em;
-}
-
-#app {
-  display: flex;
-  flex-direction: column;
-  height: 100vh;
-  position: relative;
-  width: 100vw;
+  padding: 0;
+  margin : 0;
 }

--- a/src/utils/salmon.ts
+++ b/src/utils/salmon.ts
@@ -365,7 +365,7 @@ const _getAllSalmonRoutesFromEtds = (
   return _adjustedSalmonRoutes
 }
 
-/*
+/**
  * Given a salmon route, returns the total time it takes to go back and return to
  * the origin
  */
@@ -376,6 +376,16 @@ export const getSalmonTimeFromRoute = ({
   returnRideTime,
 }: SalmonRoute): number =>
   waitTime + backwardsRideTime + backwardsWaitTime + returnRideTime
+
+/**
+ * Given a salmon route and the next upcoming train, figure out how much additional
+ * time the salmon route would add to the trip
+ */
+export const getSalmonAdditionalTime = (salmonRoute: SalmonRoute, nextTrain: Train) =>
+  // Make sure the minimal time is 0
+  // It shouldn't be less than 0 but there are some slight discrepancies between
+  // forward and backward route times
+  Math.max(0, getSalmonTimeFromRoute(salmonRoute) - nextTrain.minutes)
 
 /**
  * Given origin and destination stations, returns a list of available trains,
@@ -461,7 +471,7 @@ export const getSuggestedSalmonRoutesFromEtds = (
         'waitTime',
       ])
       // Filter out duplicate routes with the same salmon time because we basically
-      // always want to leave out on the first backwards train so that we can go as 
+      // always want to leave out on the first backwards train so that we can go as
       // far as possible with waiting as little as possible. A duplicate salmon time
       // means waiting longer for the backwards train and/or waiting longer for the
       // return train


### PR DESCRIPTION
## Problem

The arrivals UI was outdated after the work done in #40 to clean up the routes UI. Also, the routes UI and even the station selectors layout wasn't quite correct. But it didn't make sense to clean up layout until the arrivals UI was done.

## Solution

Switch over the arrivals UI to make use of [`material-ui`](https://material-ui.com/) components, like [`Chip`](https://material-ui.com/components/chips/) to display the upcoming trains and their times.

Also separated out the salmon route that catches the same train for no additional time, if it exists, from the other trains that add more time. Those headings probably could use more wordsmithing

## Screenshot

| Latest | Before | Original |
| ------- | ------ | -------------- |
| <img width="381" alt="Screen Shot 2019-11-22 at 11 33 21 PM" src="https://user-images.githubusercontent.com/5714478/69475329-86659280-0d80-11ea-8246-0ce1a38c433f.png"> | <img width="378" alt="Screen Shot 2019-11-21 at 10 22 46 PM" src="https://user-images.githubusercontent.com/5714478/69475287-31298100-0d80-11ea-98ba-39f4d4103353.png"> | <img width="380" alt="Screen Shot 2019-11-21 at 10 31 23 PM" src="https://user-images.githubusercontent.com/5714478/69475292-38508f00-0d80-11ea-95a9-e9ca981d147f.png"> |

## Issues

Fixes #30 although we're using the styling solution from `material-ui` instead of using `emotion`