### PR TITLE
Fix auto generate data workflow schedule

### DIFF
--- a/.github/workflows/auto-generate-data.yml
+++ b/.github/workflows/auto-generate-data.yml
@@ -4,7 +4,7 @@ name: Auto-generate data
 on:
   schedule:
     # 7AM UTC is 11PM PST
-    - cron: '* 7 * * *'
+    - cron: '0 7 * * *'
 
 jobs:
   auto_generate_data:


### PR DESCRIPTION
## Problem

Originally the schedule for the `auto-generate-workflow` cron schedule was: `* 7 * * *`, which means:

> At every minute past hour 7

What I want is `0 7 * * *`, which means:

> At 07:00

## Solution

Updated the `cron` attribute in the `auto-generate-data.yml`. 😅 

On the bright side, I was able to verify that the workflow _definitely_ works! 😂 