### PR TITLE
Run unit tests before pushing new auto-gen data

### DIFF
--- a/.github/workflows/auto-generate-data.yml
+++ b/.github/workflows/auto-generate-data.yml
@@ -26,6 +26,12 @@ jobs:
     - name: Generate static data
       run: npm run gen:all
 
+    # Run unit tests to make sure tests on mock data still pass
+    - name: Run unit tests w/ code coverage
+      run: npm test
+      env:
+        CI: true
+
     - name: Commit updated files
       run: |
         git config --local user.email "bartsalmon@benmvp.com"

--- a/.github/workflows/auto-generate-data.yml
+++ b/.github/workflows/auto-generate-data.yml
@@ -27,7 +27,7 @@ jobs:
       run: npm run gen:all
 
     # Run unit tests to make sure tests on mock data still pass
-    - name: Run unit tests w/ code coverage
+    - name: Run unit tests
       run: npm test
       env:
         CI: true


### PR DESCRIPTION
## Problem

The pre-processed data changed substantially in [this commit](https://github.com/benmvp/bart-salmon/commit/58e4f77f74b2a51a4b0d6cff6a960273ff574716) from the nightly Github action cron. `routes.json` changed very dramatically. As a result, the tests running on mock data failed.


## Solution

We need to push a PR that can go through all of the checks to make sure we don't make `master` fail tests. So the solution, for now, is to ensure that the tests are run _before_ pushing the new data. If the tests fail, the cron will fail and we can run the job manually w/ a PR.