### PR TITLE
Create PR with updated meta

### DIFF
--- a/.github/workflows/auto-generate-data.yml
+++ b/.github/workflows/auto-generate-data.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Create PR with updated metadata
       uses: peter-evans/create-pull-request@v1.9.1
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        token: ${{ secrets.REPO_SCOPED_TOKEN }}
         commit-message: Update metadata from nightly cron
         author-email: bart.salmon@users.noreply.github.com
         author-name: Bart Salmon GitHub Action

--- a/.github/workflows/auto-generate-data.yml
+++ b/.github/workflows/auto-generate-data.yml
@@ -5,9 +5,6 @@ on:
   schedule:
     # 7AM UTC is 11PM PST
     - cron: '0 7 * * *'
-  push:
-    branches:
-      - auto-generate-pr
 
 jobs:
   auto_generate_data:
@@ -44,22 +41,3 @@ jobs:
         assignees: benmvp
         branch: auto-generated-data
         branch-suffix: none
-
-    # # Run unit tests to make sure tests on mock data still pass
-    # - name: Run unit tests
-    #   run: npm test
-    #   env:
-    #     CI: true
-
-    # - name: Commit updated files
-    #   run: |
-    #     git config --local user.email "bartsalmon@benmvp.com"
-    #     git config --local user.name "Bart Salmon GitHub Action"
-    #     git add -A
-    #     # Do nothing if there are no changes
-    #     git diff-index --quiet HEAD || git commit -m "Update data from nightly cron"
-
-    # - name: Push data to repo
-    #   uses: ad-m/github-push-action@v0.5.0
-    #   with:
-    #     github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/auto-generate-data.yml
+++ b/.github/workflows/auto-generate-data.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     # 7AM UTC is 11PM PST
     - cron: '0 7 * * *'
+  push:
+    branches:
+      - auto-generate-pr
 
 jobs:
   auto_generate_data:
@@ -27,21 +30,36 @@ jobs:
     - name: Generate static data
       run: npm run gen:all
 
-    # Run unit tests to make sure tests on mock data still pass
-    - name: Run unit tests
-      run: npm test
-      env:
-        CI: true
-
-    - name: Commit updated files
-      run: |
-        git config --local user.email "bartsalmon@benmvp.com"
-        git config --local user.name "Bart Salmon GitHub Action"
-        git add -A
-        # Do nothing if there are no changes
-        git diff-index --quiet HEAD || git commit -m "Update data from nightly cron"
-
-    - name: Push data to repo
-      uses: ad-m/github-push-action@v0.5.0
+    # Submit pull request for any updated data (if exists)
+    - name: Create PR with updated metadata
+      uses: peter-evans/create-pull-request@v1.9.1
       with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+        token: ${{ secrets.GITHUB_TOKEN }}
+        commit-message: Update metadata from nightly cron
+        author-email: bart.salmon@users.noreply.github.com
+        author-name: Bart Salmon GitHub Action
+        title: 'Update metadata from nightly cron'
+        body: 'The nightly cron has auto-generated new metadata. Verify the changes and ensure that the tests still pass.'
+        labels: auto-generated-data
+        assignees: benmvp
+        branch: auto-generated-data
+        branch-suffix: none
+
+    # # Run unit tests to make sure tests on mock data still pass
+    # - name: Run unit tests
+    #   run: npm test
+    #   env:
+    #     CI: true
+
+    # - name: Commit updated files
+    #   run: |
+    #     git config --local user.email "bartsalmon@benmvp.com"
+    #     git config --local user.name "Bart Salmon GitHub Action"
+    #     git add -A
+    #     # Do nothing if there are no changes
+    #     git diff-index --quiet HEAD || git commit -m "Update data from nightly cron"
+
+    # - name: Push data to repo
+    #   uses: ad-m/github-push-action@v0.5.0
+    #   with:
+    #     github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,10 @@ jobs:
       env:
         CI: true
 
-    - name: Verify production build
-      run: npm run build
-
     - name: Send coverage info to Coveralls
       uses: coverallsapp/github-action@v1.0.1
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Verify production build
+      run: npm run build

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -157,9 +157,7 @@ const SettingsPage = ({
 
   return (
     <Box p={2}>
-      <Box mb={3}>
-        <Typography variant="h3" component="h1">Settings</Typography>
-      </Box>
+      <Typography variant="h3" component="h1" gutterBottom>Settings</Typography>
       <NumArrivals value={numArrivals} setValue={setNumArrivals} />
       <RiskinessFactor value={riskinessFactor} setValue={setRiskinessFactor} />
       <NumSalmonRoutes value={numSalmonRoutes} setValue={setNumSalmonRoutes} />


### PR DESCRIPTION
## Problem

The `auto-generate-data.yml` Github action creates new data, which can cause tests to fail ([for example](https://github.com/benmvp/bart-salmon/commit/8fe84e0a149c8d411b61dc623df7d88f88d080af/checks?check_suite_id=350581295)). With #50, we run the tests before pushing the new changes, but then that means that the script will continue to fail until we run `npm run gen:all` locally and then push the changes.


## Solution

The fix is to instead have the action, create a PR with the changes so that we can review it and then merge in the changes. This uses the [`peter-evans/create-pull-request`](https://github.com/marketplace/actions/create-pull-request) Github action. And if we take a long time to review the changes, new updates will continue to be pushed to the same branch (`auto-generated-data`), so the PR should always be up to date. Then when we land the PR and delete the branch, a new PR will get created pointing to the same branch.

Test PR: https://github.com/benmvp/bart-salmon/pull/58

Also:
- In `ci.yml` sending coverage data to `coveralls` _before_ verifying production build so we can get the results from them sooner. This essentially makes the production build verification and coveralls calculation parallel
- Minor styling change to `<Settings />` header
